### PR TITLE
Validation for env_var dictionary in pip install method

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -827,6 +827,9 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
 
     if env_vars:
         if isinstance(env_vars, dict):
+            for k, v in env_vars.iteritems():
+                if not isinstance(v, basestring):
+                    env_vars[k] = str(v)
             os.environ.update(env_vars)
         else:
             raise CommandExecutionError(


### PR DESCRIPTION
### What does this PR do?
This PR introduces a basic sanity check for values passed to os.environ.update and ensures they are strings.

### What issues does this PR fix or reference?
#36644 

### Previous Behavior
Values were passed to above mentioned without 

### New Behavior
Remove this section if not relevant

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
